### PR TITLE
toJsonString functions calls Json parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtGit._
 
 lazy val commonSettings = Util.settings ++ Seq(
   organization := "org.scala-sbt",
-  git.baseVersion := "0.1.0",
+  git.baseVersion := "0.1.1",
   scalaVersion := scala210Version,
   crossScalaVersions := Seq(scala210Version, scala211Version),
   libraryDependencies ++= Seq(junitInterface % Test, scalaCheck % Test)

--- a/serialization/src/main/scala/sbt/serialization/SerializedValue.scala
+++ b/serialization/src/main/scala/sbt/serialization/SerializedValue.scala
@@ -97,7 +97,6 @@ object SerializedValue {
 /** A value we have serialized as JSON */
 private final case class JsonValue(pickledValue: JSONPickle) extends SerializedValue {
   require(pickledValue ne null)
-  require(pickledValue.parsedValue ne null)
 
   import sbt.serialization.json.pickleFormat
   override def parse[T](implicit unpicklerForT: Unpickler[T]): Try[T] =


### PR DESCRIPTION
## step
1. run YourKit
2. call `sbt.serialization.toJsonString(x)`
## problem

Jawn is on the call graph. For large object, this adds huge memory and time overhead.
## expectation

`toJsonString(x)` just generates `String`.
## note

https://github.com/sbt/serialization/blob/9b5857192fea0ca108c09ee4414452c85a32ecec/serialization/src/main/scala/sbt/serialization/SerializedValue.scala#L100

``` scala
  require(pickledValue.parsedValue ne null)
```
