### PR TITLE
shareNothing to avoid refs

### DIFF
--- a/serialization/src/main/scala/sbt/serialization/package.scala
+++ b/serialization/src/main/scala/sbt/serialization/package.scala
@@ -24,5 +24,6 @@ package object serialization extends SerializationFunctions with CustomPicklers 
   // All generated picklers are required to be static-only in this library.
   implicit val StaticOnly = scala.pickling.static.StaticOnly
 
+  implicit val ShareNothing = scala.pickling.shareNothing.ShareNothing
   type directSubclasses = _root_.scala.pickling.directSubclasses
 }


### PR DESCRIPTION
## steps

pickle really large object with repeating references.
## problem

pickling creates something like `{ '$ref': 123 }`.
## expectation

stop doing that.

/review @havocp, @jsuereth 
